### PR TITLE
Patch new `InputSink` API into Foundation

### DIFF
--- a/.lune/commands/install/patches.luau
+++ b/.lune/commands/install/patches.luau
@@ -42,8 +42,15 @@ local function applyPatches(quiet: boolean?): boolean
 	table.sort(patchFiles)
 
 	for _, patchFile in patchFiles do
-		local targetDirName = patchFile:gsub("%.patch$", "")
+		local baseName = patchFile:gsub("%.patch$", "")
+		local targetDirName = baseName
 		local targetPath = `{PACKAGES_INDEX_DIR}/{targetDirName}`
+
+		-- If no directory matches the full name, strip sequence number suffix (e.g., "_2")
+		if not fs.isDir(targetPath) then
+			targetDirName = baseName:gsub("_%d+$", "")
+			targetPath = `{PACKAGES_INDEX_DIR}/{targetDirName}`
+		end
 
 		if not fs.isDir(targetPath) then
 			if not quiet then

--- a/.lune/commands/patch.luau
+++ b/.lune/commands/patch.luau
@@ -129,8 +129,17 @@ local function generatePatch(packagePath: string, packageDirName: string): boole
 		fs.writeDir(PATCHES_DIR)
 	end
 
-	-- Write the patch file
+	-- Find next available patch filename
 	local patchFilePath = `{PATCHES_DIR}/{packageDirName}.patch`
+	if fs.isFile(patchFilePath) then
+		local n = 2
+		while fs.isFile(`{PATCHES_DIR}/{packageDirName}_{n}.patch`) do
+			n += 1
+		end
+		patchFilePath = `{PATCHES_DIR}/{packageDirName}_{n}.patch`
+	end
+
+	-- Write the patch file
 	fs.writeFile(patchFilePath, diff)
 
 	print()

--- a/plugin/patches/Foundation_2.patch
+++ b/plugin/patches/Foundation_2.patch
@@ -1,0 +1,93 @@
+diff --git a/Foundation/Components/Dialog/Dialog.lua b/Foundation/Components/Dialog/Dialog.lua
+index 433e423..953f107 100644
+--- a/Foundation/Components/Dialog/Dialog.lua
++++ b/Foundation/Components/Dialog/Dialog.lua
+@@ -90,6 +90,7 @@ local function Dialog(dialogProps: DialogInternalProps)
+ 				end,
+ 				backgroundStyle = variants.backdrop.backgroundStyle,
+ 				ZIndex = 2,
++				InputSink = Enum.InputSink.All,
+ 				testId = `{props.testId}--backdrop`,
+ 			})
+ 			else nil,
+diff --git a/Foundation/Components/Popover/Content/PopoverContent.lua b/Foundation/Components/Popover/Content/PopoverContent.lua
+index 709467c..c91e3fe 100644
+--- a/Foundation/Components/Popover/Content/PopoverContent.lua
++++ b/Foundation/Components/Popover/Content/PopoverContent.lua
+@@ -205,6 +205,7 @@ local function PopoverContent(contentProps: PopoverContentProps, forwardedRef: R
+ 					Position = position:map(function(value: Vector2)
+ 						return UDim2.fromOffset(value.X, value.Y)
+ 					end),
++					InputSink = Enum.InputSink.All,
+ 					selection = props.selection,
+ 					selectionGroup = props.selectionGroup,
+ 					sizeConstraint = {
+diff --git a/Foundation/Components/Sheet/BottomSheet.lua b/Foundation/Components/Sheet/BottomSheet.lua
+index 6e8ff45..23f964c 100644
+--- a/Foundation/Components/Sheet/BottomSheet.lua
++++ b/Foundation/Components/Sheet/BottomSheet.lua
+@@ -523,6 +523,7 @@ local function BottomSheet(sheetProps: SheetProps, ref: React.Ref<Instance>)
+ 						Size = UDim2.fromScale(1, 2),
+ 						Position = UDim2.fromScale(0, -0.5),
+ 						ZIndex = 1,
++						InputSink = Enum.InputSink.All,
+ 						stateLayer = {
+ 							affordance = StateLayerAffordance.None,
+ 						},
+diff --git a/Foundation/Components/Sheet/CenterSheet.lua b/Foundation/Components/Sheet/CenterSheet.lua
+index b01deb7..31dbc4d 100644
+--- a/Foundation/Components/Sheet/CenterSheet.lua
++++ b/Foundation/Components/Sheet/CenterSheet.lua
+@@ -294,6 +294,7 @@ local function CenterSheet(centerSheetProps: CenterSheetProps, ref: React.Ref<Gu
+ 					Size = UDim2.fromScale(2, 2),
+ 					Position = UDim2.fromScale(-0.5, -0.5),
+ 					ZIndex = 1,
++					InputSink = Enum.InputSink.All,
+ 					stateLayer = {
+ 						affordance = StateLayerAffordance.None,
+ 					},
+diff --git a/Foundation/Components/Sheet/SideSheet.lua b/Foundation/Components/Sheet/SideSheet.lua
+index 5961e13..996505a 100644
+--- a/Foundation/Components/Sheet/SideSheet.lua
++++ b/Foundation/Components/Sheet/SideSheet.lua
+@@ -270,6 +270,7 @@ local function SideSheet(sideSheetProps: SideSheetProps, ref: React.Ref<GuiObjec
+ 					Size = UDim2.fromScale(2, 2),
+ 					Position = UDim2.fromScale(-0.5, -0.5),
+ 					ZIndex = 1,
++					InputSink = Enum.InputSink.All,
+ 					stateLayer = {
+ 						affordance = StateLayerAffordance.None,
+ 					},
+diff --git a/Foundation/Components/Types.lua b/Foundation/Components/Types.lua
+index a60cea7..7f429cb 100644
+--- a/Foundation/Components/Types.lua
++++ b/Foundation/Components/Types.lua
+@@ -176,6 +176,8 @@ export type BaseGuiObjectProps = {
+ 	Size: Bindable<UDim2?>,
+ 	SizeConstraint: Bindable<Enum.SizeConstraint>?,
+ 
++	InputSink: Bindable<Enum.InputSink>?,
++
+ 	tag: Tags?,
+ 	children: React.ReactNode?,
+ }
+diff --git a/Foundation/Utility/withGuiObjectProps.lua b/Foundation/Utility/withGuiObjectProps.lua
+index bfbf456..a4b8817 100644
+--- a/Foundation/Utility/withGuiObjectProps.lua
++++ b/Foundation/Utility/withGuiObjectProps.lua
+@@ -38,6 +38,7 @@ type AppliedGuiObjectProps = {
+ 	NextSelectionRight: Bindable<ReactRefGuiObject>?,
+ 	NextSelectionUp: Bindable<ReactRefGuiObject>?,
+ 	Size: Bindable<UDim2>?,
++	InputSink: Bindable<Enum.InputSink>?,
+ } & NativeCommonProps
+ 
+ local function withGuiObjectProps<T>(props: GuiObjectProps & CommonProps, baseProps: T)
+@@ -56,6 +57,7 @@ local function withGuiObjectProps<T>(props: GuiObjectProps & CommonProps, basePr
+ 		baseProps.ClipsDescendants = props.ClipsDescendants
+ 		baseProps.Rotation = props.Rotation
+ 		baseProps.SizeConstraint = props.SizeConstraint
++		baseProps.InputSink = props.InputSink
+ 
+ 		if props.selection then
+ 			baseProps.Selectable = props.selection.Selectable


### PR DESCRIPTION
Roblox has a new `InputSink` API! It allows you to stop mouse events from firing behind a UI element.

This PR:
- Updates the package patching system so we can patch the same package multiple times
- Patches Foundation so popover, sheet, and dialog all use InputSink