### PR TITLE
Avoid play solo bugs by disabling the plugin while the DataModel is running

### DIFF
--- a/plugin/bin/setup.luau
+++ b/plugin/bin/setup.luau
@@ -1,3 +1,4 @@
+local RunService = game:GetService("RunService")
 local Plugin = script:FindFirstAncestor("StudioActivity")
 
 local Packages = Plugin.Packages
@@ -11,6 +12,14 @@ export type PluginMain = (plugin: Plugin, pluginLoaderContext: createPluginLoade
 
 local function setup(plugin: Plugin, main: PluginMain)
 	plugin.Name = "StudioActivity"
+
+	-- Currently, the plugin breaks in weird ways when running in Play Solo.
+	-- While I come up with a better long-term solution, we're just going to
+	-- block the plugin from running if we're in an active DataModel.
+	-- See: https://github.com/grilme99/studio-activity/issues/6
+	if RunService:IsRunning() then
+		return
+	end
 
 	-- Derive dev-mode globals from BuildVars before any module that reads them
 	local BuildVars = require(Plugin.Source.BuildVars)

--- a/plugin/bin/setup.luau
+++ b/plugin/bin/setup.luau
@@ -1,4 +1,5 @@
 local RunService = game:GetService("RunService")
+
 local Plugin = script:FindFirstAncestor("StudioActivity")
 
 local Packages = Plugin.Packages

--- a/plugin/wally.lock
+++ b/plugin/wally.lock
@@ -3,8 +3,8 @@
 registry = "test"
 
 [[package]]
-name = "brhodes/studio-rich-presence"
-version = "0.1.0"
+name = "brhodes/studio-activity"
+version = "0.3.1"
 dependencies = [["Chalk", "jsdotlua/chalk@0.2.1"], ["Charm", "grilme99/charm@0.11.0-rc.3"], ["Jest", "jsdotlua/jest@3.10.0"], ["JestGlobals", "jsdotlua/jest-globals@3.10.0"], ["Log", "realthx1/luaulog@0.3.0"], ["React", "jsdotlua/react@17.2.1"], ["ReactCharm", "grilme99/react-charm@0.4.0-rc.3"], ["ReactFlow", "outofbears/react-flow@0.4.0"], ["ReactRoblox", "jsdotlua/react-roblox@17.2.1"], ["Sift", "csqrl/sift@0.0.8"], ["Signal", "stravant/goodsignal@0.3.1"], ["Storyteller", "flipbook-labs/storyteller@1.8.1"], ["png", "grilme99/png-luau@0.2.1"], ["sha256", "dekkonot/sha256@1.0.1"], ["t", "osyrisrblx/t@3.1.1"]]
 
 [[package]]


### PR DESCRIPTION
See: #6 

We can't create user-space standalone DM plugins, so there's a lot of bugs to iron out with the plugin running under Play Solo (aka a running DataModel). For such a stateful plugin, things break in weird ways when you introduce a new copy of it running under a different DM.

For now, we intentionally block the plugin from starting if it's inside a running DataModel. I may remove this restriction in the future.