### PR TITLE
Upgrade React

### DIFF
--- a/.lune/commands/install/init.luau
+++ b/.lune/commands/install/init.luau
@@ -11,6 +11,7 @@ local applyPatches = require("./install/patches")
 local color = require("../utils/color")
 local exec = require("../lib/process/exec")
 local installFoundation = require("./install/foundation")
+local redirectPackages = require("./install/redirectPackages")
 local rojo = require("../lib/project/rojo")
 
 local install = {}
@@ -158,6 +159,22 @@ function install.run(options_: Options?): boolean
 		print(color.bold(color.white("Successfully installed Foundation packages!")))
 	end
 
+	-- Wally has no support for deduping packages published by different
+	-- authors. We pull React from haedrix in plugin/wally.toml, but our
+	-- transitive deps (and Foundation's own React.lua shims) still point
+	-- at jsdotlua/react. Collapse the duplicates onto haedrix here so
+	-- there is a single canonical React across the package graph.
+	if not quiet then
+		print(color.dim("Redirecting jsdotlua packages to haedrix..."))
+	end
+	local redirectResult = redirectPackages.byAuthor("plugin/Packages/_Index", "jsdotlua", "haedrix", quiet)
+	if not redirectResult then
+		if not quiet then
+			print(color.bold(color.red("Failed to redirect packages")))
+		end
+		return false
+	end
+
 	-- Apply patches to Wally packages
 	if not quiet then
 		print(color.dim("Applying package patches..."))
@@ -173,6 +190,19 @@ function install.run(options_: Options?): boolean
 
 	if not quiet then
 		print(color.bold(color.white("Successfully applied package patches!")))
+	end
+
+	local sourcemapResult2, sourcemapStdout2 = rojo.sourcemap({
+		projectFile = PROJECT_FILE,
+		output = SOURCEMAP_PATH,
+		includeNonScripts = true,
+	})
+	if not sourcemapResult2 then
+		if not quiet then
+			print(color.bold(color.red("Failed to generate project sourcemap")))
+			stdio.write(sourcemapStdout2)
+		end
+		return false
 	end
 
 	return true

--- a/.lune/commands/install/redirectPackages.luau
+++ b/.lune/commands/install/redirectPackages.luau
@@ -1,0 +1,182 @@
+--[[
+	Package Redirection
+
+	Wally has no support for deduping packages published by different
+	authors, or for patching transitive dependency references after
+	install. This module fills that gap: it deletes a set of installed
+	package directories under `<packagesDir>/_Index/` and rewrites every
+	top-level `*.lua` shim so references to the removed names are
+	redirected to their replacements.
+
+	Two entry points:
+
+	  redirectPackages.apply(packagesDir, { ["old@1"] = "new@2" }, quiet)
+	    - Low-level primitive. Caller supplies the rename map directly.
+
+	  redirectPackages.byAuthor(packagesDir, "fromAuthor", "toAuthor", quiet)
+	    - Convenience. Discovers `<fromAuthor>_<name>@<v>` directories and
+	      pairs each with the unique `<toAuthor>_<name>@<v>` sibling, then
+	      delegates to `apply`. This matches the canonical case of
+	      converging two registries that publish overlapping packages.
+]]
+
+local fs = require("@lune/fs")
+
+local color = require("../../utils/color")
+
+--[[
+	Replaces every plain-text occurrence of `needle` in `content` with
+	`replacement`. Avoids string.gsub so callers do not have to escape
+	pattern metacharacters in package names like `@` and `.`.
+]]
+local function plainReplaceAll(content: string, needle: string, replacement: string): string
+	if not string.find(content, needle, 1, true) then
+		return content
+	end
+	return table.concat(content:split(needle), replacement)
+end
+
+--[[
+	Rewrites a single shim file in place, applying every rename in the map.
+]]
+local function rewriteShim(path: string, renames: { [string]: string })
+	local original = fs.readFile(path)
+	local contents = original
+	for from, to in renames do
+		contents = plainReplaceAll(contents, from, to)
+	end
+	if contents ~= original then
+		fs.writeFile(path, contents)
+	end
+end
+
+--[[
+	Walks every top-level `.lua` shim under `<packagesDir>/<pkg>/` and
+	rewrites references to renamed packages.
+]]
+local function rewriteAllShims(packagesDir: string, renames: { [string]: string })
+	for _, pkg in fs.readDir(packagesDir) do
+		local pkgPath = `{packagesDir}/{pkg}`
+		if not fs.isDir(pkgPath) then
+			continue
+		end
+
+		for _, file in fs.readDir(pkgPath) do
+			if not file:match("%.lua$") then
+				continue
+			end
+			local filePath = `{pkgPath}/{file}`
+			if fs.isFile(filePath) then
+				rewriteShim(filePath, renames)
+			end
+		end
+	end
+end
+
+local redirectPackages = {}
+
+--[[
+	Applies an explicit rename map: deletes each `from` directory under
+	`packagesDir` and rewrites every shim to point at the `to` directory.
+
+	@param packagesDir Path to the package index (e.g. "plugin/Packages/_Index")
+	@param renames Map of directory names to redirect (from -> to)
+	@param quiet Whether to suppress output
+	@return True on success, false on error
+]]
+function redirectPackages.apply(packagesDir: string, renames: { [string]: string }, quiet: boolean?): boolean
+	if next(renames) == nil then
+		return true
+	end
+
+	if not fs.isDir(packagesDir) then
+		if not quiet then
+			print(color.yellow(`  Package directory not found: {packagesDir}`))
+		end
+		return false
+	end
+
+	if not quiet then
+		for from, to in renames do
+			print(color.dim(`  Redirecting {from} -> {to}`))
+		end
+	end
+
+	-- Delete first, then rewrite. Walking the index after deletion means we
+	-- never try to read a shim inside a directory that no longer exists.
+	for from in renames do
+		local pkgPath = `{packagesDir}/{from}`
+		if fs.isDir(pkgPath) then
+			fs.removeDir(pkgPath)
+		end
+	end
+
+	rewriteAllShims(packagesDir, renames)
+
+	return true
+end
+
+--[[
+	Builds a rename map by pairing every `<fromAuthor>_<name>@<v>` directory
+	in `packagesDir` with its unique `<toAuthor>_<name>@<v>` sibling, then
+	delegates to `redirectPackages.apply`.
+
+	Authors without a matching sibling are left alone (no entry in the map).
+	Errors if more than one sibling matches a single from-author package.
+
+	@param packagesDir Path to the package index (e.g. "plugin/Packages/_Index")
+	@param fromAuthor The author whose packages should be removed
+	@param toAuthor The author whose packages should be kept
+	@param quiet Whether to suppress output
+	@return True on success, false on error
+]]
+function redirectPackages.byAuthor(packagesDir: string, fromAuthor: string, toAuthor: string, quiet: boolean?): boolean
+	if not fs.isDir(packagesDir) then
+		return true
+	end
+
+	local entries = fs.readDir(packagesDir)
+	local fromPattern = `^{fromAuthor}_(.-)@`
+	local toPrefix = `{toAuthor}_`
+
+	local renames: { [string]: string } = {}
+	for _, entry in entries do
+		local depName = entry:match(fromPattern)
+		if depName == nil then
+			continue
+		end
+		if not fs.isDir(`{packagesDir}/{entry}`) then
+			continue
+		end
+
+		local siblingPrefix = `{toPrefix}{depName}@`
+		local matches: { string } = {}
+		for _, candidate in entries do
+			if candidate:sub(1, #siblingPrefix) == siblingPrefix and fs.isDir(`{packagesDir}/{candidate}`) then
+				table.insert(matches, candidate)
+			end
+		end
+
+		if #matches == 0 then
+			continue
+		end
+		if #matches > 1 then
+			if not quiet then
+				print(
+					color.bold(
+						color.red(
+							`Expected at most one {toAuthor} sibling for {entry}, found {#matches}: `
+								.. table.concat(matches, ", ")
+						)
+					)
+				)
+			end
+			return false
+		end
+		renames[entry] = matches[1]
+	end
+
+	return redirectPackages.apply(packagesDir, renames, quiet)
+end
+
+return redirectPackages

--- a/plugin/bin/setup.luau
+++ b/plugin/bin/setup.luau
@@ -24,8 +24,9 @@ local function setup(plugin: Plugin, main: PluginMain)
 
 	-- Derive dev-mode globals from BuildVars before any module that reads them
 	local BuildVars = require(Plugin.Source.BuildVars)
-	_G.__DEV__ = BuildVars.build.isDev
-	_G.__LOG_LEVEL__ = if BuildVars.build.isDev then "info" else "warn"
+
+	local ReactGlobals = require(Plugin.Packages.ReactGlobals)
+	ReactGlobals.__DEV__ = BuildVars.build.isDev
 
 	-- Set plugin instance early so settings stores can load auth from disk
 	local PluginStore = require(Plugin.Source.Plugin.PluginStore)

--- a/plugin/src/Logger.luau
+++ b/plugin/src/Logger.luau
@@ -3,6 +3,8 @@ local Plugin = script:FindFirstAncestor("StudioActivity")
 local Packages = Plugin.Packages
 local Log = require(Packages.Log)
 
+local BuildVars = require(Plugin.Source.BuildVars)
+
 local function stringToLogLevel(logLevel: string)
 	if logLevel == "info" then
 		return Log.LogLevel.Information
@@ -17,7 +19,7 @@ local function stringToLogLevel(logLevel: string)
 end
 
 local sinks = {}
-if _G.__DEV__ then
+if BuildVars.build.isDev then
 	table.insert(sinks, Log.Common.RobloxLogSink())
 end
 
@@ -28,7 +30,7 @@ local logger = Log.Logger.new(
 	},
 	sinks,
 	{
-		Log.Common.Filters.MinLevelFilter(stringToLogLevel(_G.__LOG_LEVEL__)),
+		Log.Common.Filters.MinLevelFilter(stringToLogLevel(if BuildVars.build.isDev then "info" else "warn")),
 	}
 )
 

--- a/plugin/wally.lock
+++ b/plugin/wally.lock
@@ -5,23 +5,7 @@ registry = "test"
 [[package]]
 name = "brhodes/studio-activity"
 version = "0.3.1"
-dependencies = [
-	["Chalk", "jsdotlua/chalk@0.2.1"],
-	["Charm", "grilme99/charm@0.11.0-rc.3"],
-	["Jest", "jsdotlua/jest@3.10.0"],
-	["JestGlobals", "jsdotlua/jest-globals@3.10.0"],
-	["Log", "realthx1/luaulog@0.3.0"],
-	["React", "jsdotlua/react@17.2.1"],
-	["ReactCharm", "grilme99/react-charm@0.4.0-rc.3"],
-	["ReactFlow", "outofbears/react-flow@0.4.0"],
-	["ReactRoblox", "jsdotlua/react-roblox@17.2.1"],
-	["Sift", "csqrl/sift@0.0.8"],
-	["Signal", "stravant/goodsignal@0.3.1"],
-	["Storyteller", "flipbook-labs/storyteller@1.8.1"],
-	["png", "grilme99/png-luau@0.2.1"],
-	["sha256", "dekkonot/sha256@1.0.1"],
-	["t", "osyrisrblx/t@3.1.1"],
-]
+dependencies = [["Chalk", "jsdotlua/chalk@0.2.1"], ["Charm", "grilme99/charm@0.11.0-rc.3"], ["Jest", "jsdotlua/jest@3.10.0"], ["JestGlobals", "jsdotlua/jest-globals@3.10.0"], ["Log", "realthx1/luaulog@0.3.0"], ["React", "haedrix/react@17.3.8"], ["ReactCharm", "grilme99/react-charm@0.4.0-rc.3"], ["ReactFlow", "outofbears/react-flow@0.4.0"], ["ReactGlobals", "haedrix/react-globals@17.3.8"], ["ReactRoblox", "haedrix/react-roblox@17.3.8"], ["Sift", "csqrl/sift@0.0.8"], ["Signal", "stravant/goodsignal@0.3.1"], ["Storyteller", "flipbook-labs/storyteller@1.8.1"], ["png", "grilme99/png-luau@0.2.1"], ["sha256", "dekkonot/sha256@1.0.1"], ["t", "osyrisrblx/t@3.1.1"]]
 
 [[package]]
 name = "corecii/greentea"
@@ -56,34 +40,12 @@ dependencies = []
 [[package]]
 name = "flipbook-labs/module-loader"
 version = "0.7.0"
-dependencies = [
-	["Janitor", "howmanysmall/janitor@1.18.3"],
-	["Jest", "jsdotlua/jest@3.10.0"],
-	["JestGlobals", "jsdotlua/jest-globals@3.10.0"],
-	["LuauPolyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["Sift", "csqrl/sift@0.0.8"],
-]
+dependencies = [["Janitor", "howmanysmall/janitor@1.18.3"], ["Jest", "jsdotlua/jest@3.10.0"], ["JestGlobals", "jsdotlua/jest-globals@3.10.0"], ["LuauPolyfill", "jsdotlua/luau-polyfill@1.2.7"], ["Sift", "csqrl/sift@0.0.8"]]
 
 [[package]]
 name = "flipbook-labs/storyteller"
 version = "1.8.1"
-dependencies = [
-	["Charm", "littensy/charm@0.11.0-rc.4"],
-	["Fusion", "elttob/fusion@0.2.0"],
-	["Fusion3", "elttob/fusion@0.3.0"],
-	["GreenTea", "corecii/greentea@0.4.11"],
-	["Jest", "jsdotlua/jest@3.10.0"],
-	["JestGlobals", "jsdotlua/jest-globals@3.10.0"],
-	["ModuleLoader", "flipbook-labs/module-loader@0.7.0"],
-	["React", "jsdotlua/react@17.2.1"],
-	["ReactCharm", "littensy/react-charm@0.4.0-rc.3"],
-	["ReactRoblox", "jsdotlua/react-roblox@17.2.1"],
-	["Roact", "roblox/roact@1.4.4"],
-	["RoactCompat", "jsdotlua/roact-compat@17.2.1"],
-	["Sift", "csqrl/sift@0.0.8"],
-	["UILabs", "pepeeltoro41/ui-labs@2.4.2"],
-	["t", "osyrisrblx/t@3.1.1"],
-]
+dependencies = [["Charm", "littensy/charm@0.11.0-rc.4"], ["Fusion", "elttob/fusion@0.2.0"], ["Fusion3", "elttob/fusion@0.3.0"], ["GreenTea", "corecii/greentea@0.4.11"], ["Jest", "jsdotlua/jest@3.10.0"], ["JestGlobals", "jsdotlua/jest-globals@3.10.0"], ["ModuleLoader", "flipbook-labs/module-loader@0.7.0"], ["React", "jsdotlua/react@17.2.1"], ["ReactCharm", "littensy/react-charm@0.4.0-rc.3"], ["ReactRoblox", "jsdotlua/react-roblox@17.2.1"], ["Roact", "roblox/roact@1.4.4"], ["RoactCompat", "jsdotlua/roact-compat@17.2.1"], ["Sift", "csqrl/sift@0.0.8"], ["UILabs", "pepeeltoro41/ui-labs@2.4.2"], ["t", "osyrisrblx/t@3.1.1"]]
 
 [[package]]
 name = "grilme99/charm"
@@ -98,31 +60,57 @@ dependencies = []
 [[package]]
 name = "grilme99/react-charm"
 version = "0.4.0-rc.3"
-dependencies = [
-	["Charm", "grilme99/charm@0.11.0-rc.3"],
-	["React", "jsdotlua/react@17.2.1"],
-]
+dependencies = [["Charm", "grilme99/charm@0.11.0-rc.3"], ["React", "jsdotlua/react@17.2.1"]]
+
+[[package]]
+name = "haedrix/react"
+version = "17.3.8"
+dependencies = [["LuauPolyfill", "jsdotlua/luau-polyfill@1.2.7"], ["ReactGlobals", "haedrix/react-globals@17.3.8"], ["Shared", "haedrix/shared@17.3.8"]]
+
+[[package]]
+name = "haedrix/react-globals"
+version = "17.3.8"
+dependencies = [["SafeFlags", "haedrix/safe-flags@0.1.1"]]
+
+[[package]]
+name = "haedrix/react-reconciler"
+version = "17.3.8"
+dependencies = [["LuauPolyfill", "jsdotlua/luau-polyfill@1.2.7"], ["Promise", "evaera/promise@4.0.0"], ["React", "haedrix/react@17.3.8"], ["ReactGlobals", "haedrix/react-globals@17.3.8"], ["SafeFlags", "haedrix/safe-flags@0.1.1"], ["Scheduler", "haedrix/scheduler@17.3.8"], ["Shared", "haedrix/shared@17.3.8"]]
+
+[[package]]
+name = "haedrix/react-roblox"
+version = "17.3.8"
+dependencies = [["LuauPolyfill", "jsdotlua/luau-polyfill@1.2.7"], ["React", "haedrix/react@17.3.8"], ["ReactGlobals", "haedrix/react-globals@17.3.8"], ["ReactReconciler", "haedrix/react-reconciler@17.3.8"], ["Scheduler", "haedrix/scheduler@17.3.8"], ["Shared", "haedrix/shared@17.3.8"]]
+
+[[package]]
+name = "haedrix/safe-flags"
+version = "0.1.1"
+dependencies = []
+
+[[package]]
+name = "haedrix/scheduler"
+version = "17.3.8"
+dependencies = [["LuauPolyfill", "jsdotlua/luau-polyfill@1.2.7"], ["ReactGlobals", "haedrix/react-globals@17.3.8"], ["SafeFlags", "haedrix/safe-flags@0.1.1"], ["Shared", "haedrix/shared@17.3.8"]]
+
+[[package]]
+name = "haedrix/shared"
+version = "17.3.8"
+dependencies = [["LuauPolyfill", "jsdotlua/luau-polyfill@1.2.7"], ["ReactGlobals", "haedrix/react-globals@17.3.8"], ["SafeFlags", "haedrix/safe-flags@0.1.1"]]
 
 [[package]]
 name = "howmanysmall/janitor"
 version = "1.18.3"
-dependencies = [
-	["Promise", "howmanysmall/typed-promise@4.0.6"],
-]
+dependencies = [["Promise", "howmanysmall/typed-promise@4.0.6"]]
 
 [[package]]
 name = "howmanysmall/typed-promise"
 version = "4.0.6"
-dependencies = [
-	["Promise", "evaera/promise@4.0.0"],
-]
+dependencies = [["Promise", "evaera/promise@4.0.0"]]
 
 [[package]]
 name = "jsdotlua/boolean"
 version = "1.2.7"
-dependencies = [
-	["number", "jsdotlua/number@1.2.7"],
-]
+dependencies = [["number", "jsdotlua/number@1.2.7"]]
 
 [[package]]
 name = "jsdotlua/chalk"
@@ -132,32 +120,22 @@ dependencies = []
 [[package]]
 name = "jsdotlua/collections"
 version = "1.2.7"
-dependencies = [
-	["es7-types", "jsdotlua/es7-types@1.2.7"],
-	["instance-of", "jsdotlua/instance-of@1.2.7"],
-]
+dependencies = [["es7-types", "jsdotlua/es7-types@1.2.7"], ["instance-of", "jsdotlua/instance-of@1.2.7"]]
 
 [[package]]
 name = "jsdotlua/console"
 version = "1.2.7"
-dependencies = [
-	["collections", "jsdotlua/collections@1.2.7"],
-]
+dependencies = [["collections", "jsdotlua/collections@1.2.7"]]
 
 [[package]]
 name = "jsdotlua/diff-sequences"
 version = "3.10.0"
-dependencies = [
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-]
+dependencies = [["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"]]
 
 [[package]]
 name = "jsdotlua/emittery"
 version = "3.10.0"
-dependencies = [
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["promise", "jsdotlua/promise@3.5.2"],
-]
+dependencies = [["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["promise", "jsdotlua/promise@3.5.2"]]
 
 [[package]]
 name = "jsdotlua/es7-types"
@@ -167,17 +145,7 @@ dependencies = []
 [[package]]
 name = "jsdotlua/expect"
 version = "3.10.0"
-dependencies = [
-	["jest-get-type", "jsdotlua/jest-get-type@3.10.0"],
-	["jest-matcher-utils", "jsdotlua/jest-matcher-utils@3.10.0"],
-	["jest-message-util", "jsdotlua/jest-message-util@3.10.0"],
-	["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"],
-	["jest-snapshot", "jsdotlua/jest-snapshot@3.10.0"],
-	["jest-util", "jsdotlua/jest-util@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["luau-regexp", "jsdotlua/luau-regexp@0.2.1"],
-	["promise", "jsdotlua/promise@3.5.2"],
-]
+dependencies = [["jest-get-type", "jsdotlua/jest-get-type@3.10.0"], ["jest-matcher-utils", "jsdotlua/jest-matcher-utils@3.10.0"], ["jest-message-util", "jsdotlua/jest-message-util@3.10.0"], ["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"], ["jest-snapshot", "jsdotlua/jest-snapshot@3.10.0"], ["jest-util", "jsdotlua/jest-util@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["luau-regexp", "jsdotlua/luau-regexp@0.2.1"], ["promise", "jsdotlua/promise@3.5.2"]]
 
 [[package]]
 name = "jsdotlua/instance-of"
@@ -187,331 +155,132 @@ dependencies = []
 [[package]]
 name = "jsdotlua/jest"
 version = "3.10.0"
-dependencies = [
-	["jest-core", "jsdotlua/jest-core@3.10.0"],
-]
+dependencies = [["jest-core", "jsdotlua/jest-core@3.10.0"]]
 
 [[package]]
 name = "jsdotlua/jest-circus"
 version = "3.10.0"
-dependencies = [
-	["chalk", "jsdotlua/chalk@0.2.1"],
-	["expect", "jsdotlua/expect@3.10.0"],
-	["jest-each", "jsdotlua/jest-each@3.10.0"],
-	["jest-environment", "jsdotlua/jest-environment@3.10.0"],
-	["jest-matcher-utils", "jsdotlua/jest-matcher-utils@3.10.0"],
-	["jest-message-util", "jsdotlua/jest-message-util@3.10.0"],
-	["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"],
-	["jest-runtime", "jsdotlua/jest-runtime@3.10.0"],
-	["jest-snapshot", "jsdotlua/jest-snapshot@3.10.0"],
-	["jest-test-result", "jsdotlua/jest-test-result@3.10.0"],
-	["jest-types", "jsdotlua/jest-types@3.10.0"],
-	["jest-util", "jsdotlua/jest-util@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["luau-regexp", "jsdotlua/luau-regexp@0.2.1"],
-	["pretty-format", "jsdotlua/pretty-format@3.10.0"],
-	["promise", "jsdotlua/promise@3.5.2"],
-	["throat", "jsdotlua/throat@3.10.0"],
-]
+dependencies = [["chalk", "jsdotlua/chalk@0.2.1"], ["expect", "jsdotlua/expect@3.10.0"], ["jest-each", "jsdotlua/jest-each@3.10.0"], ["jest-environment", "jsdotlua/jest-environment@3.10.0"], ["jest-matcher-utils", "jsdotlua/jest-matcher-utils@3.10.0"], ["jest-message-util", "jsdotlua/jest-message-util@3.10.0"], ["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"], ["jest-runtime", "jsdotlua/jest-runtime@3.10.0"], ["jest-snapshot", "jsdotlua/jest-snapshot@3.10.0"], ["jest-test-result", "jsdotlua/jest-test-result@3.10.0"], ["jest-types", "jsdotlua/jest-types@3.10.0"], ["jest-util", "jsdotlua/jest-util@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["luau-regexp", "jsdotlua/luau-regexp@0.2.1"], ["pretty-format", "jsdotlua/pretty-format@3.10.0"], ["promise", "jsdotlua/promise@3.5.2"], ["throat", "jsdotlua/throat@3.10.0"]]
 
 [[package]]
 name = "jsdotlua/jest-config"
 version = "3.10.0"
-dependencies = [
-	["chalk", "jsdotlua/chalk@0.2.1"],
-	["jest-each", "jsdotlua/jest-each@3.10.0"],
-	["jest-environment-roblox", "jsdotlua/jest-environment-roblox@3.10.0"],
-	["jest-get-type", "jsdotlua/jest-get-type@3.10.0"],
-	["jest-message-util", "jsdotlua/jest-message-util@3.10.0"],
-	["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"],
-	["jest-types", "jsdotlua/jest-types@3.10.0"],
-	["jest-util", "jsdotlua/jest-util@3.10.0"],
-	["jest-validate", "jsdotlua/jest-validate@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["luau-regexp", "jsdotlua/luau-regexp@0.2.1"],
-	["promise", "jsdotlua/promise@3.5.2"],
-]
+dependencies = [["chalk", "jsdotlua/chalk@0.2.1"], ["jest-each", "jsdotlua/jest-each@3.10.0"], ["jest-environment-roblox", "jsdotlua/jest-environment-roblox@3.10.0"], ["jest-get-type", "jsdotlua/jest-get-type@3.10.0"], ["jest-message-util", "jsdotlua/jest-message-util@3.10.0"], ["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"], ["jest-types", "jsdotlua/jest-types@3.10.0"], ["jest-util", "jsdotlua/jest-util@3.10.0"], ["jest-validate", "jsdotlua/jest-validate@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["luau-regexp", "jsdotlua/luau-regexp@0.2.1"], ["promise", "jsdotlua/promise@3.5.2"]]
 
 [[package]]
 name = "jsdotlua/jest-console"
 version = "3.10.0"
-dependencies = [
-	["chalk", "jsdotlua/chalk@0.2.1"],
-	["jest-each", "jsdotlua/jest-each@3.10.0"],
-	["jest-message-util", "jsdotlua/jest-message-util@3.10.0"],
-	["jest-mock", "jsdotlua/jest-mock@3.10.0"],
-	["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"],
-	["jest-types", "jsdotlua/jest-types@3.10.0"],
-	["jest-util", "jsdotlua/jest-util@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-]
+dependencies = [["chalk", "jsdotlua/chalk@0.2.1"], ["jest-each", "jsdotlua/jest-each@3.10.0"], ["jest-message-util", "jsdotlua/jest-message-util@3.10.0"], ["jest-mock", "jsdotlua/jest-mock@3.10.0"], ["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"], ["jest-types", "jsdotlua/jest-types@3.10.0"], ["jest-util", "jsdotlua/jest-util@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"]]
 
 [[package]]
 name = "jsdotlua/jest-core"
 version = "3.10.0"
-dependencies = [
-	["chalk", "jsdotlua/chalk@0.2.1"],
-	["emittery", "jsdotlua/emittery@3.10.0"],
-	["jest-config", "jsdotlua/jest-config@3.10.0"],
-	["jest-console", "jsdotlua/jest-console@3.10.0"],
-	["jest-message-util", "jsdotlua/jest-message-util@3.10.0"],
-	["jest-reporters", "jsdotlua/jest-reporters@3.10.0"],
-	["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"],
-	["jest-runner", "jsdotlua/jest-runner@3.10.0"],
-	["jest-runtime", "jsdotlua/jest-runtime@3.10.0"],
-	["jest-snapshot", "jsdotlua/jest-snapshot@3.10.0"],
-	["jest-test-result", "jsdotlua/jest-test-result@3.10.0"],
-	["jest-types", "jsdotlua/jest-types@3.10.0"],
-	["jest-util", "jsdotlua/jest-util@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["luau-regexp", "jsdotlua/luau-regexp@0.2.1"],
-	["pretty-format", "jsdotlua/pretty-format@3.10.0"],
-	["promise", "jsdotlua/promise@3.5.2"],
-]
+dependencies = [["chalk", "jsdotlua/chalk@0.2.1"], ["emittery", "jsdotlua/emittery@3.10.0"], ["jest-config", "jsdotlua/jest-config@3.10.0"], ["jest-console", "jsdotlua/jest-console@3.10.0"], ["jest-message-util", "jsdotlua/jest-message-util@3.10.0"], ["jest-reporters", "jsdotlua/jest-reporters@3.10.0"], ["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"], ["jest-runner", "jsdotlua/jest-runner@3.10.0"], ["jest-runtime", "jsdotlua/jest-runtime@3.10.0"], ["jest-snapshot", "jsdotlua/jest-snapshot@3.10.0"], ["jest-test-result", "jsdotlua/jest-test-result@3.10.0"], ["jest-types", "jsdotlua/jest-types@3.10.0"], ["jest-util", "jsdotlua/jest-util@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["luau-regexp", "jsdotlua/luau-regexp@0.2.1"], ["pretty-format", "jsdotlua/pretty-format@3.10.0"], ["promise", "jsdotlua/promise@3.5.2"]]
 
 [[package]]
 name = "jsdotlua/jest-diff"
 version = "3.10.0"
-dependencies = [
-	["chalk", "jsdotlua/chalk@0.2.1"],
-	["diff-sequences", "jsdotlua/diff-sequences@3.10.0"],
-	["jest-get-type", "jsdotlua/jest-get-type@3.10.0"],
-	["jest-types", "jsdotlua/jest-types@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["pretty-format", "jsdotlua/pretty-format@3.10.0"],
-]
+dependencies = [["chalk", "jsdotlua/chalk@0.2.1"], ["diff-sequences", "jsdotlua/diff-sequences@3.10.0"], ["jest-get-type", "jsdotlua/jest-get-type@3.10.0"], ["jest-types", "jsdotlua/jest-types@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["pretty-format", "jsdotlua/pretty-format@3.10.0"]]
 
 [[package]]
 name = "jsdotlua/jest-each"
 version = "3.10.0"
-dependencies = [
-	["chalk", "jsdotlua/chalk@0.2.1"],
-	["jest-get-type", "jsdotlua/jest-get-type@3.10.0"],
-	["jest-types", "jsdotlua/jest-types@3.10.0"],
-	["jest-util", "jsdotlua/jest-util@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["luau-regexp", "jsdotlua/luau-regexp@0.2.1"],
-	["pretty-format", "jsdotlua/pretty-format@3.10.0"],
-]
+dependencies = [["chalk", "jsdotlua/chalk@0.2.1"], ["jest-get-type", "jsdotlua/jest-get-type@3.10.0"], ["jest-types", "jsdotlua/jest-types@3.10.0"], ["jest-util", "jsdotlua/jest-util@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["luau-regexp", "jsdotlua/luau-regexp@0.2.1"], ["pretty-format", "jsdotlua/pretty-format@3.10.0"]]
 
 [[package]]
 name = "jsdotlua/jest-environment"
 version = "3.10.0"
-dependencies = [
-	["jest-fake-timers", "jsdotlua/jest-fake-timers@3.10.0"],
-	["jest-mock", "jsdotlua/jest-mock@3.10.0"],
-	["jest-mock-genv", "jsdotlua/jest-mock-genv@3.10.0"],
-	["jest-types", "jsdotlua/jest-types@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-]
+dependencies = [["jest-fake-timers", "jsdotlua/jest-fake-timers@3.10.0"], ["jest-mock", "jsdotlua/jest-mock@3.10.0"], ["jest-mock-genv", "jsdotlua/jest-mock-genv@3.10.0"], ["jest-types", "jsdotlua/jest-types@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"]]
 
 [[package]]
 name = "jsdotlua/jest-environment-roblox"
 version = "3.10.0"
-dependencies = [
-	["jest-environment", "jsdotlua/jest-environment@3.10.0"],
-	["jest-fake-timers", "jsdotlua/jest-fake-timers@3.10.0"],
-	["jest-mock", "jsdotlua/jest-mock@3.10.0"],
-	["jest-types", "jsdotlua/jest-types@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["promise", "jsdotlua/promise@3.5.2"],
-]
+dependencies = [["jest-environment", "jsdotlua/jest-environment@3.10.0"], ["jest-fake-timers", "jsdotlua/jest-fake-timers@3.10.0"], ["jest-mock", "jsdotlua/jest-mock@3.10.0"], ["jest-types", "jsdotlua/jest-types@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["promise", "jsdotlua/promise@3.5.2"]]
 
 [[package]]
 name = "jsdotlua/jest-fake-timers"
 version = "3.10.0"
-dependencies = [
-	["jest-get-type", "jsdotlua/jest-get-type@3.10.0"],
-	["jest-mock", "jsdotlua/jest-mock@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-]
+dependencies = [["jest-get-type", "jsdotlua/jest-get-type@3.10.0"], ["jest-mock", "jsdotlua/jest-mock@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"]]
 
 [[package]]
 name = "jsdotlua/jest-get-type"
 version = "3.10.0"
-dependencies = [
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["luau-regexp", "jsdotlua/luau-regexp@0.2.1"],
-]
+dependencies = [["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["luau-regexp", "jsdotlua/luau-regexp@0.2.1"]]
 
 [[package]]
 name = "jsdotlua/jest-globals"
 version = "3.10.0"
-dependencies = [
-	["expect", "jsdotlua/expect@3.10.0"],
-	["jest-environment", "jsdotlua/jest-environment@3.10.0"],
-	["jest-types", "jsdotlua/jest-types@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-]
+dependencies = [["expect", "jsdotlua/expect@3.10.0"], ["jest-environment", "jsdotlua/jest-environment@3.10.0"], ["jest-types", "jsdotlua/jest-types@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"]]
 
 [[package]]
 name = "jsdotlua/jest-matcher-utils"
 version = "3.10.0"
-dependencies = [
-	["chalk", "jsdotlua/chalk@0.2.1"],
-	["jest-diff", "jsdotlua/jest-diff@3.10.0"],
-	["jest-get-type", "jsdotlua/jest-get-type@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["luau-regexp", "jsdotlua/luau-regexp@0.2.1"],
-	["pretty-format", "jsdotlua/pretty-format@3.10.0"],
-]
+dependencies = [["chalk", "jsdotlua/chalk@0.2.1"], ["jest-diff", "jsdotlua/jest-diff@3.10.0"], ["jest-get-type", "jsdotlua/jest-get-type@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["luau-regexp", "jsdotlua/luau-regexp@0.2.1"], ["pretty-format", "jsdotlua/pretty-format@3.10.0"]]
 
 [[package]]
 name = "jsdotlua/jest-message-util"
 version = "3.10.0"
-dependencies = [
-	["chalk", "jsdotlua/chalk@0.2.1"],
-	["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"],
-	["jest-types", "jsdotlua/jest-types@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["luau-regexp", "jsdotlua/luau-regexp@0.2.1"],
-	["pretty-format", "jsdotlua/pretty-format@3.10.0"],
-]
+dependencies = [["chalk", "jsdotlua/chalk@0.2.1"], ["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"], ["jest-types", "jsdotlua/jest-types@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["luau-regexp", "jsdotlua/luau-regexp@0.2.1"], ["pretty-format", "jsdotlua/pretty-format@3.10.0"]]
 
 [[package]]
 name = "jsdotlua/jest-mock"
 version = "3.10.0"
-dependencies = [
-	["jest-mock-genv", "jsdotlua/jest-mock-genv@3.10.0"],
-	["jest-types", "jsdotlua/jest-types@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-]
+dependencies = [["jest-mock-genv", "jsdotlua/jest-mock-genv@3.10.0"], ["jest-types", "jsdotlua/jest-types@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"]]
 
 [[package]]
 name = "jsdotlua/jest-mock-genv"
 version = "3.10.0"
-dependencies = [
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-]
+dependencies = [["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"]]
 
 [[package]]
 name = "jsdotlua/jest-reporters"
 version = "3.10.0"
-dependencies = [
-	["chalk", "jsdotlua/chalk@0.2.1"],
-	["jest-console", "jsdotlua/jest-console@3.10.0"],
-	["jest-message-util", "jsdotlua/jest-message-util@3.10.0"],
-	["jest-mock", "jsdotlua/jest-mock@3.10.0"],
-	["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"],
-	["jest-test-result", "jsdotlua/jest-test-result@3.10.0"],
-	["jest-types", "jsdotlua/jest-types@3.10.0"],
-	["jest-util", "jsdotlua/jest-util@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["path", "jsdotlua/path@3.10.0"],
-]
+dependencies = [["chalk", "jsdotlua/chalk@0.2.1"], ["jest-console", "jsdotlua/jest-console@3.10.0"], ["jest-message-util", "jsdotlua/jest-message-util@3.10.0"], ["jest-mock", "jsdotlua/jest-mock@3.10.0"], ["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"], ["jest-test-result", "jsdotlua/jest-test-result@3.10.0"], ["jest-types", "jsdotlua/jest-types@3.10.0"], ["jest-util", "jsdotlua/jest-util@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["path", "jsdotlua/path@3.10.0"]]
 
 [[package]]
 name = "jsdotlua/jest-roblox-shared"
 version = "3.10.0"
-dependencies = [
-	["jest-get-type", "jsdotlua/jest-get-type@3.10.0"],
-	["jest-mock", "jsdotlua/jest-mock@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-]
+dependencies = [["jest-get-type", "jsdotlua/jest-get-type@3.10.0"], ["jest-mock", "jsdotlua/jest-mock@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"]]
 
 [[package]]
 name = "jsdotlua/jest-runner"
 version = "3.10.0"
-dependencies = [
-	["chalk", "jsdotlua/chalk@0.2.1"],
-	["emittery", "jsdotlua/emittery@3.10.0"],
-	["jest-circus", "jsdotlua/jest-circus@3.10.0"],
-	["jest-console", "jsdotlua/jest-console@3.10.0"],
-	["jest-environment", "jsdotlua/jest-environment@3.10.0"],
-	["jest-message-util", "jsdotlua/jest-message-util@3.10.0"],
-	["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"],
-	["jest-runtime", "jsdotlua/jest-runtime@3.10.0"],
-	["jest-test-result", "jsdotlua/jest-test-result@3.10.0"],
-	["jest-types", "jsdotlua/jest-types@3.10.0"],
-	["jest-util", "jsdotlua/jest-util@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["pretty-format", "jsdotlua/pretty-format@3.10.0"],
-	["promise", "jsdotlua/promise@3.5.2"],
-	["throat", "jsdotlua/throat@3.10.0"],
-]
+dependencies = [["chalk", "jsdotlua/chalk@0.2.1"], ["emittery", "jsdotlua/emittery@3.10.0"], ["jest-circus", "jsdotlua/jest-circus@3.10.0"], ["jest-console", "jsdotlua/jest-console@3.10.0"], ["jest-environment", "jsdotlua/jest-environment@3.10.0"], ["jest-message-util", "jsdotlua/jest-message-util@3.10.0"], ["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"], ["jest-runtime", "jsdotlua/jest-runtime@3.10.0"], ["jest-test-result", "jsdotlua/jest-test-result@3.10.0"], ["jest-types", "jsdotlua/jest-types@3.10.0"], ["jest-util", "jsdotlua/jest-util@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["pretty-format", "jsdotlua/pretty-format@3.10.0"], ["promise", "jsdotlua/promise@3.5.2"], ["throat", "jsdotlua/throat@3.10.0"]]
 
 [[package]]
 name = "jsdotlua/jest-runtime"
 version = "3.10.0"
-dependencies = [
-	["emittery", "jsdotlua/emittery@3.10.0"],
-	["expect", "jsdotlua/expect@3.10.0"],
-	["jest-fake-timers", "jsdotlua/jest-fake-timers@3.10.0"],
-	["jest-mock", "jsdotlua/jest-mock@3.10.0"],
-	["jest-mock-genv", "jsdotlua/jest-mock-genv@3.10.0"],
-	["jest-snapshot", "jsdotlua/jest-snapshot@3.10.0"],
-	["jest-types", "jsdotlua/jest-types@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["promise", "jsdotlua/promise@3.5.2"],
-]
+dependencies = [["emittery", "jsdotlua/emittery@3.10.0"], ["expect", "jsdotlua/expect@3.10.0"], ["jest-fake-timers", "jsdotlua/jest-fake-timers@3.10.0"], ["jest-mock", "jsdotlua/jest-mock@3.10.0"], ["jest-mock-genv", "jsdotlua/jest-mock-genv@3.10.0"], ["jest-snapshot", "jsdotlua/jest-snapshot@3.10.0"], ["jest-types", "jsdotlua/jest-types@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["promise", "jsdotlua/promise@3.5.2"]]
 
 [[package]]
 name = "jsdotlua/jest-snapshot"
 version = "3.10.0"
-dependencies = [
-	["chalk", "jsdotlua/chalk@0.2.1"],
-	["jest-diff", "jsdotlua/jest-diff@3.10.0"],
-	["jest-get-type", "jsdotlua/jest-get-type@3.10.0"],
-	["jest-matcher-utils", "jsdotlua/jest-matcher-utils@3.10.0"],
-	["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"],
-	["jest-types", "jsdotlua/jest-types@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["pretty-format", "jsdotlua/pretty-format@3.10.0"],
-	["promise", "jsdotlua/promise@3.5.2"],
-]
+dependencies = [["chalk", "jsdotlua/chalk@0.2.1"], ["jest-diff", "jsdotlua/jest-diff@3.10.0"], ["jest-get-type", "jsdotlua/jest-get-type@3.10.0"], ["jest-matcher-utils", "jsdotlua/jest-matcher-utils@3.10.0"], ["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"], ["jest-types", "jsdotlua/jest-types@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["pretty-format", "jsdotlua/pretty-format@3.10.0"], ["promise", "jsdotlua/promise@3.5.2"]]
 
 [[package]]
 name = "jsdotlua/jest-test-result"
 version = "3.10.0"
-dependencies = [
-	["jest-types", "jsdotlua/jest-types@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-]
+dependencies = [["jest-types", "jsdotlua/jest-types@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"]]
 
 [[package]]
 name = "jsdotlua/jest-types"
 version = "3.10.0"
-dependencies = [
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["luau-regexp", "jsdotlua/luau-regexp@0.2.1"],
-]
+dependencies = [["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["luau-regexp", "jsdotlua/luau-regexp@0.2.1"]]
 
 [[package]]
 name = "jsdotlua/jest-util"
 version = "3.10.0"
-dependencies = [
-	["chalk", "jsdotlua/chalk@0.2.1"],
-	["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"],
-	["jest-types", "jsdotlua/jest-types@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["luau-regexp", "jsdotlua/luau-regexp@0.2.1"],
-	["picomatch", "jsdotlua/picomatch@0.4.0"],
-	["promise", "jsdotlua/promise@3.5.2"],
-]
+dependencies = [["chalk", "jsdotlua/chalk@0.2.1"], ["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"], ["jest-types", "jsdotlua/jest-types@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["luau-regexp", "jsdotlua/luau-regexp@0.2.1"], ["picomatch", "jsdotlua/picomatch@0.4.0"], ["promise", "jsdotlua/promise@3.5.2"]]
 
 [[package]]
 name = "jsdotlua/jest-validate"
 version = "3.10.0"
-dependencies = [
-	["chalk", "jsdotlua/chalk@0.2.1"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-]
+dependencies = [["chalk", "jsdotlua/chalk@0.2.1"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"]]
 
 [[package]]
 name = "jsdotlua/luau-polyfill"
 version = "1.2.7"
-dependencies = [
-	["boolean", "jsdotlua/boolean@1.2.7"],
-	["collections", "jsdotlua/collections@1.2.7"],
-	["console", "jsdotlua/console@1.2.7"],
-	["es7-types", "jsdotlua/es7-types@1.2.7"],
-	["instance-of", "jsdotlua/instance-of@1.2.7"],
-	["math", "jsdotlua/math@1.2.7"],
-	["number", "jsdotlua/number@1.2.7"],
-	["string", "jsdotlua/string@1.2.7"],
-	["symbol-luau", "jsdotlua/symbol-luau@1.0.1"],
-	["timers", "jsdotlua/timers@1.2.7"],
-]
+dependencies = [["boolean", "jsdotlua/boolean@1.2.7"], ["collections", "jsdotlua/collections@1.2.7"], ["console", "jsdotlua/console@1.2.7"], ["es7-types", "jsdotlua/es7-types@1.2.7"], ["instance-of", "jsdotlua/instance-of@1.2.7"], ["math", "jsdotlua/math@1.2.7"], ["number", "jsdotlua/number@1.2.7"], ["string", "jsdotlua/string@1.2.7"], ["symbol-luau", "jsdotlua/symbol-luau@1.0.1"], ["timers", "jsdotlua/timers@1.2.7"]]
 
 [[package]]
 name = "jsdotlua/luau-regexp"
@@ -531,30 +300,17 @@ dependencies = []
 [[package]]
 name = "jsdotlua/path"
 version = "3.10.0"
-dependencies = [
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-]
+dependencies = [["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"]]
 
 [[package]]
 name = "jsdotlua/picomatch"
 version = "0.4.0"
-dependencies = [
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["luau-regexp", "jsdotlua/luau-regexp@0.2.1"],
-	["promise", "jsdotlua/promise@3.5.2"],
-]
+dependencies = [["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["luau-regexp", "jsdotlua/luau-regexp@0.2.1"], ["promise", "jsdotlua/promise@3.5.2"]]
 
 [[package]]
 name = "jsdotlua/pretty-format"
 version = "3.10.0"
-dependencies = [
-	["chalk", "jsdotlua/chalk@0.2.1"],
-	["jest-get-type", "jsdotlua/jest-get-type@3.10.0"],
-	["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"],
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["luau-regexp", "jsdotlua/luau-regexp@0.2.1"],
-	["react-is", "jsdotlua/react-is@17.2.1"],
-]
+dependencies = [["chalk", "jsdotlua/chalk@0.2.1"], ["jest-get-type", "jsdotlua/jest-get-type@3.10.0"], ["jest-roblox-shared", "jsdotlua/jest-roblox-shared@3.10.0"], ["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["luau-regexp", "jsdotlua/luau-regexp@0.2.1"], ["react-is", "jsdotlua/react-is@17.2.1"]]
 
 [[package]]
 name = "jsdotlua/promise"
@@ -564,72 +320,42 @@ dependencies = []
 [[package]]
 name = "jsdotlua/react"
 version = "17.2.1"
-dependencies = [
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["shared", "jsdotlua/shared@17.2.1"],
-]
+dependencies = [["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["shared", "jsdotlua/shared@17.2.1"]]
 
 [[package]]
 name = "jsdotlua/react-is"
 version = "17.2.1"
-dependencies = [
-	["shared", "jsdotlua/shared@17.2.1"],
-]
+dependencies = [["shared", "jsdotlua/shared@17.2.1"]]
 
 [[package]]
 name = "jsdotlua/react-reconciler"
 version = "17.2.1"
-dependencies = [
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["promise", "jsdotlua/promise@3.5.2"],
-	["react", "jsdotlua/react@17.2.1"],
-	["scheduler", "jsdotlua/scheduler@17.2.1"],
-	["shared", "jsdotlua/shared@17.2.1"],
-]
+dependencies = [["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["promise", "jsdotlua/promise@3.5.2"], ["react", "jsdotlua/react@17.2.1"], ["scheduler", "jsdotlua/scheduler@17.2.1"], ["shared", "jsdotlua/shared@17.2.1"]]
 
 [[package]]
 name = "jsdotlua/react-roblox"
 version = "17.2.1"
-dependencies = [
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["react", "jsdotlua/react@17.2.1"],
-	["react-reconciler", "jsdotlua/react-reconciler@17.2.1"],
-	["scheduler", "jsdotlua/scheduler@17.2.1"],
-	["shared", "jsdotlua/shared@17.2.1"],
-]
+dependencies = [["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["react", "jsdotlua/react@17.2.1"], ["react-reconciler", "jsdotlua/react-reconciler@17.2.1"], ["scheduler", "jsdotlua/scheduler@17.2.1"], ["shared", "jsdotlua/shared@17.2.1"]]
 
 [[package]]
 name = "jsdotlua/roact-compat"
 version = "17.2.1"
-dependencies = [
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["react", "jsdotlua/react@17.2.1"],
-	["react-roblox", "jsdotlua/react-roblox@17.2.1"],
-	["shared", "jsdotlua/shared@17.2.1"],
-]
+dependencies = [["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["react", "jsdotlua/react@17.2.1"], ["react-roblox", "jsdotlua/react-roblox@17.2.1"], ["shared", "jsdotlua/shared@17.2.1"]]
 
 [[package]]
 name = "jsdotlua/scheduler"
 version = "17.2.1"
-dependencies = [
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["shared", "jsdotlua/shared@17.2.1"],
-]
+dependencies = [["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["shared", "jsdotlua/shared@17.2.1"]]
 
 [[package]]
 name = "jsdotlua/shared"
 version = "17.2.1"
-dependencies = [
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-]
+dependencies = [["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"]]
 
 [[package]]
 name = "jsdotlua/string"
 version = "1.2.7"
-dependencies = [
-	["es7-types", "jsdotlua/es7-types@1.2.7"],
-	["number", "jsdotlua/number@1.2.7"],
-]
+dependencies = [["es7-types", "jsdotlua/es7-types@1.2.7"], ["number", "jsdotlua/number@1.2.7"]]
 
 [[package]]
 name = "jsdotlua/symbol-luau"
@@ -639,17 +365,12 @@ dependencies = []
 [[package]]
 name = "jsdotlua/throat"
 version = "3.10.0"
-dependencies = [
-	["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"],
-	["promise", "jsdotlua/promise@3.5.2"],
-]
+dependencies = [["luau-polyfill", "jsdotlua/luau-polyfill@1.2.7"], ["promise", "jsdotlua/promise@3.5.2"]]
 
 [[package]]
 name = "jsdotlua/timers"
 version = "1.2.7"
-dependencies = [
-	["collections", "jsdotlua/collections@1.2.7"],
-]
+dependencies = [["collections", "jsdotlua/collections@1.2.7"]]
 
 [[package]]
 name = "littensy/charm"
@@ -659,10 +380,7 @@ dependencies = []
 [[package]]
 name = "littensy/react-charm"
 version = "0.4.0-rc.3"
-dependencies = [
-	["Charm", "littensy/charm@0.11.0-rc.4"],
-	["React", "jsdotlua/react@17.2.1"],
-]
+dependencies = [["Charm", "littensy/charm@0.11.0-rc.4"], ["React", "jsdotlua/react@17.2.1"]]
 
 [[package]]
 name = "osyrisrblx/t"
@@ -672,11 +390,7 @@ dependencies = []
 [[package]]
 name = "outofbears/react-flow"
 version = "0.4.0"
-dependencies = [
-	["Promise", "evaera/promise@4.0.0"],
-	["React", "jsdotlua/react@17.2.1"],
-	["ReactRoblox", "jsdotlua/react-roblox@17.2.1"],
-]
+dependencies = [["Promise", "evaera/promise@4.0.0"], ["React", "jsdotlua/react@17.2.1"], ["ReactRoblox", "jsdotlua/react-roblox@17.2.1"]]
 
 [[package]]
 name = "pepeeltoro41/ui-labs"
@@ -697,4 +411,3 @@ dependencies = []
 name = "stravant/goodsignal"
 version = "0.3.1"
 dependencies = []
-

--- a/plugin/wally.toml
+++ b/plugin/wally.toml
@@ -9,8 +9,9 @@ private = true
 # shared-packages = "game.ReplicatedStorage.Packages"
 
 [dependencies]
-React = "jsdotlua/react@17.2.1"
-ReactRoblox = "jsdotlua/react-roblox@17.2.1"
+React = "haedrix/react@17.3.8"
+ReactRoblox = "haedrix/react-roblox@17.3.8"
+ReactGlobals = "haedrix/react-globals@17.3.8"
 ReactFlow = "outofbears/react-flow@0.4.0"
 Log = "realthx1/luaulog@0.3.0"
 Sift = "csqrl/sift@0.0.8"

--- a/selene.toml
+++ b/selene.toml
@@ -1,9 +1,5 @@
 std = "roblox"
 
-[config]
-# Allow for `_G.__DEV__` (etc) with packages like React-lua
-global_usage = { ignore_pattern = "^__" }
-
 [rules]
 # We don't need this rule because the Luau analyzer already checks for this.
 incorrect_standard_library_use = "allow"


### PR DESCRIPTION
Upgrade to the latest version of React available to the community by switching to the `haedrix` version. To do this, we need to add another step to the install workflow that patches transitive Wally dependencies to the `jsdotlua` React. 

We also conveniently get rid of `_G` usage because we can use `ReactGlobals` now, which is nice.