### PR TITLE
Fix telemetry wire format and tests

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -98,6 +98,7 @@ dependencies = [
  "pbjson-types",
  "prost",
  "prost-build",
+ "prost-reflect",
  "serde",
  "serde_json",
  "thiserror",
@@ -664,6 +665,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "pbjson"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +839,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-reflect"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
+dependencies = [
+ "base64",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde-value",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,6 +982,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -22,6 +22,7 @@ tracing-subscriber = { version = "0.3", features = ['time', 'json'] }
 time = { version = "0.3", features = ['wasm-bindgen'] }
 serde = { version = "1.0.228", features = ["derive"] }
 prost = "0.14"
+prost-reflect = { version = "0.16", features = ["serde"] }
 pbjson = "0.9"
 pbjson-types = "0.9"
 serde_json = "1.0"

--- a/backend/build.rs
+++ b/backend/build.rs
@@ -29,12 +29,12 @@ fn main() -> Result<()> {
     config.file_descriptor_set_path(&descriptor_path);
     config.compile_well_known_types();
 
-    // Give the oneof enum a plain serde Serialize so decompose_event()
+    // Give the oneof enum a snake_case serde Serialize so decompose_event()
     // can split it into (event_name, properties) via the externally-tagged
     // representation. pbjson handles everything else.
     config.type_attribute(
         ".api.v1.TelemetryRequest.event",
-        "#[derive(serde::Serialize)]",
+        "#[derive(serde::Serialize)]\n#[serde(rename_all = \"snake_case\")]",
     );
 
     config.compile_protos(&protos, &[proto_root])?;

--- a/backend/src/posthog.rs
+++ b/backend/src/posthog.rs
@@ -21,6 +21,9 @@
 //! We do **not** collect: Roblox usernames, place names or IDs, game
 //! content, file paths, system information, or any free-form text.
 
+use once_cell::sync::Lazy;
+use prost::Message;
+use prost_reflect::{DescriptorPool, DynamicMessage, SerializeOptions};
 use serde_json::{json, Value};
 use worker::wasm_bindgen::JsValue;
 use worker::{Fetch, Headers, Method, Request, RequestInit};
@@ -30,24 +33,67 @@ use crate::proto::{telemetry_request::Event, TelemetryRequest};
 const POSTHOG_CAPTURE_PATH: &str = "/i/v0/e/";
 const LIB_NAME: &str = "studio-activity-backend";
 const LIB_VERSION: &str = env!("CARGO_PKG_VERSION");
+const TELEMETRY_REQUEST_DESCRIPTOR_NAME: &str = "api.v1.TelemetryRequest";
+
+static DESCRIPTOR_POOL: Lazy<DescriptorPool> = Lazy::new(|| {
+    DescriptorPool::decode(include_bytes!(concat!(env!("OUT_DIR"), "/proto_descriptor.bin")).as_ref())
+        .expect("api.v1 descriptor pool")
+});
+
+fn posthog_serialize_options() -> SerializeOptions {
+    SerializeOptions::new()
+        .use_proto_field_name(true)
+        // Keep enum values in their canonical proto JSON string form.
+        .skip_default_fields(false)
+}
 
 /// Decomposes a proto `Event` into its snake_case event name and a flat
-/// properties JSON object by leveraging the serde `Serialize` derive.
+/// properties JSON object by using `prost-reflect`'s JSON serializer.
 ///
-/// The `Event` enum serializes as an externally-tagged enum, e.g.
-/// `{"auth_started": {"has_existing_credentials": true}}`. We split
-/// that into `("auth_started", {"has_existing_credentials": true})`.
+/// We serialize via reflection so we can apply PostHog-specific options
+/// without changing the plugin-facing pbjson wire format:
+/// - `use_proto_field_name(true)` for snake_case keys
+/// - `skip_default_fields(false)` so false/0/"" are preserved
 ///
 /// Null values (from unset `optional` proto fields) are stripped so
 /// only properties that were actually provided are forwarded.
 pub fn decompose_event(event: &Event) -> (String, Value) {
-    let serialized = serde_json::to_value(event).unwrap_or_default();
+    let descriptor = match DESCRIPTOR_POOL.get_message_by_name(TELEMETRY_REQUEST_DESCRIPTOR_NAME) {
+        Some(descriptor) => descriptor,
+        None => return (String::new(), json!({})),
+    };
 
-    let Value::Object(map) = serialized else {
+    // Wrap in TelemetryRequest so the oneof field name itself gives us
+    // the event name in proto snake_case.
+    let mut request = TelemetryRequest::default();
+    request.event = Some(event.clone());
+
+    let encoded = request.encode_to_vec();
+    let dynamic = match DynamicMessage::decode(descriptor.clone(), encoded.as_slice()) {
+        Ok(dynamic) => dynamic,
+        Err(_) => return (String::new(), json!({})),
+    };
+
+    let mut serializer = serde_json::Serializer::new(Vec::new());
+    if dynamic
+        .serialize_with_options(&mut serializer, &posthog_serialize_options())
+        .is_err()
+    {
+        return (String::new(), json!({}));
+    }
+
+    let serialized: Value = serde_json::from_slice(&serializer.into_inner()).unwrap_or_default();
+    let Value::Object(mut map) = serialized else {
         return (String::new(), json!({}));
     };
 
-    let Some((name, mut properties)) = map.into_iter().next() else {
+    let Some(event_oneof) = descriptor.oneofs().find(|oneof| oneof.name() == "event") else {
+        return (String::new(), json!({}));
+    };
+    let Some((name, mut properties)) = event_oneof
+        .fields()
+        .find_map(|field| map.remove(field.name()).map(|value| (field.name().to_owned(), value)))
+    else {
         return (String::new(), json!({}));
     };
 

--- a/backend/tests/wasm/telemetry.rs
+++ b/backend/tests/wasm/telemetry.rs
@@ -19,12 +19,10 @@ use crate::helpers::{inject_edge, mock_edge_context, test_router};
 async fn deserialize_plugin_loaded() {
     let json = r#"{
         "distinctId": "user-1",
-        "event": {
-            "pluginLoaded": {
-                "accountCount": 2,
-                "isPresenceActive": true,
-                "activeProfile": "default"
-            }
+        "pluginLoaded": {
+            "accountCount": 2,
+            "isPresenceActive": true,
+            "activeProfile": "default"
         }
     }"#;
     let req: TelemetryRequest = serde_json::from_str(json).unwrap();
@@ -41,7 +39,7 @@ async fn deserialize_plugin_loaded() {
 
 #[wasm_bindgen_test]
 async fn deserialize_plugin_loaded_defaults() {
-    let json = r#"{"distinctId":"user-1","event":{"pluginLoaded":{}}}"#;
+    let json = r#"{"distinctId":"user-1","pluginLoaded":{}}"#;
     let req: TelemetryRequest = serde_json::from_str(json).unwrap();
     match req.event {
         Some(telemetry_request::Event::PluginLoaded(PluginLoaded {
@@ -59,7 +57,7 @@ async fn deserialize_plugin_loaded_defaults() {
 
 #[wasm_bindgen_test]
 async fn deserialize_ui_opened() {
-    let json = r#"{"distinctId":"user-2","event":{"uiOpened":{}}}"#;
+    let json = r#"{"distinctId":"user-2","uiOpened":{}}"#;
     let req: TelemetryRequest = serde_json::from_str(json).unwrap();
     assert!(matches!(
         req.event,
@@ -71,9 +69,7 @@ async fn deserialize_ui_opened() {
 async fn deserialize_onboarding_completed() {
     let json = r#"{
         "distinctId": "user-3",
-        "event": {
-            "onboardingCompleted": { "optedIntoTelemetry": true }
-        }
+        "onboardingCompleted": { "optedIntoTelemetry": true }
     }"#;
     let req: TelemetryRequest = serde_json::from_str(json).unwrap();
     assert!(matches!(
@@ -90,12 +86,10 @@ async fn deserialize_onboarding_completed() {
 async fn deserialize_account_linked() {
     let json = r#"{
         "distinctId": "user-4",
-        "event": {
-            "accountLinked": {
-                "accountCount": 1,
-                "isFirstAccount": true,
-                "linkFlow": 1
-            }
+        "accountLinked": {
+            "accountCount": 1,
+            "isFirstAccount": true,
+            "linkFlow": 1
         }
     }"#;
     let req: TelemetryRequest = serde_json::from_str(json).unwrap();
@@ -113,9 +107,7 @@ async fn deserialize_account_linked() {
 async fn deserialize_device_code_flow_failed() {
     let json = r#"{
         "distinctId": "user-5",
-        "event": {
-            "deviceCodeFlowFailed": { "error": "expired" }
-        }
+        "deviceCodeFlowFailed": { "error": "expired" }
     }"#;
     let req: TelemetryRequest = serde_json::from_str(json).unwrap();
     match req.event {
@@ -130,9 +122,7 @@ async fn deserialize_device_code_flow_failed() {
 async fn deserialize_browser_flow_failed() {
     let json = r#"{
         "distinctId": "user-5b",
-        "event": {
-            "browserFlowFailed": { "error": "timeout" }
-        }
+        "browserFlowFailed": { "error": "timeout" }
     }"#;
     let req: TelemetryRequest = serde_json::from_str(json).unwrap();
     match req.event {
@@ -147,7 +137,7 @@ async fn deserialize_browser_flow_failed() {
 async fn deserialize_presence_toggled() {
     let json = r#"{
         "distinctId": "user-6",
-        "event": { "presenceToggled": { "isActive": false } }
+        "presenceToggled": { "isActive": false }
     }"#;
     let req: TelemetryRequest = serde_json::from_str(json).unwrap();
     assert!(matches!(
@@ -162,7 +152,7 @@ async fn deserialize_presence_toggled() {
 async fn deserialize_profile_selected() {
     let json = r#"{
         "distinctId": "user-7",
-        "event": { "profileSelected": { "profile": "minimal" } }
+        "profileSelected": { "profile": "minimal" }
     }"#;
     let req: TelemetryRequest = serde_json::from_str(json).unwrap();
     match req.event {
@@ -177,7 +167,7 @@ async fn deserialize_profile_selected() {
 async fn deserialize_session_error() {
     let json = r#"{
         "distinctId": "user-8",
-        "event": { "sessionError": { "error": "refresh_failed" } }
+        "sessionError": { "error": "refresh_failed" }
     }"#;
     let req: TelemetryRequest = serde_json::from_str(json).unwrap();
     match req.event {
@@ -195,7 +185,7 @@ async fn deserialize_with_plugin_metadata() {
         "pluginVersion": "1.2.0",
         "pluginChannel": "stable",
         "pluginHash": "abc123",
-        "event": { "uiOpened": {} }
+        "uiOpened": {}
     }"#;
     let req: TelemetryRequest = serde_json::from_str(json).unwrap();
     assert_eq!(req.plugin_version, "1.2.0");
@@ -209,7 +199,7 @@ async fn deserialize_with_plugin_metadata() {
 
 #[wasm_bindgen_test]
 async fn reject_unknown_event_variant() {
-    let json = r#"{"distinctId":"u","event":{"madeUpEvent":{}}}"#;
+    let json = r#"{"distinctId":"u","madeUpEvent":{}}"#;
     let result = serde_json::from_str::<TelemetryRequest>(json);
     assert!(result.is_err(), "unknown event variant should be rejected");
 }
@@ -218,9 +208,7 @@ async fn reject_unknown_event_variant() {
 async fn reject_unknown_fields_on_event() {
     let json = r#"{
         "distinctId": "u",
-        "event": {
-            "accountLinked": { "accountCount": 1, "isFirstAccount": true, "extra": 42 }
-        }
+        "accountLinked": { "accountCount": 1, "isFirstAccount": true, "extra": 42 }
     }"#;
     let result = serde_json::from_str::<TelemetryRequest>(json);
     assert!(
@@ -233,7 +221,7 @@ async fn reject_unknown_fields_on_event() {
 async fn reject_unknown_fields_on_request() {
     let json = r#"{
         "distinctId": "u",
-        "event": {"uiOpened": {}},
+        "uiOpened": {},
         "extraTopLevel": true
     }"#;
     let result = serde_json::from_str::<TelemetryRequest>(json);
@@ -244,7 +232,7 @@ async fn reject_unknown_fields_on_request() {
 async fn reject_wrong_property_types() {
     let json = r#"{
         "distinctId": "u",
-        "event": { "presenceToggled": { "isActive": "yes" } }
+        "presenceToggled": { "isActive": "yes" }
     }"#;
     let result = serde_json::from_str::<TelemetryRequest>(json);
     assert!(result.is_err(), "wrong property type should be rejected");
@@ -276,7 +264,7 @@ async fn decompose_includes_event_properties() {
     assert_eq!(name, "account_linked");
     assert_eq!(props["account_count"], 2);
     assert_eq!(props["is_first_account"], false);
-    assert_eq!(props["link_flow"], 1);
+    assert_eq!(props["link_flow"], "ACCOUNT_LINK_FLOW_DEVICE_CODE");
 }
 
 #[wasm_bindgen_test]
@@ -316,7 +304,7 @@ async fn telemetry_missing_content_type_returns_error() {
     let req = inject_edge(
         Request::post("/v1/telemetry")
             .body(Body::from(
-                r#"{"distinctId":"u","event":{"pluginLoaded":{}}}"#,
+                r#"{"distinctId":"u","pluginLoaded":{}}"#,
             ))
             .unwrap(),
         mock_edge_context(),

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -3,7 +3,7 @@ main = "build/index.js"
 compatibility_date = "2026-04-05"
 
 [build]
-command = "cargo install -q \"worker-build@^0.7\" && worker-build --release"
+command = "cargo install -q \"worker-build@^0.8\" && worker-build --release"
 
 [vars]
 POSTHOG_HOST = "https://us.i.posthog.com"


### PR DESCRIPTION
## Summary
- Fix `decompose_event` to serialize telemetry via `prost-reflect` + descriptor metadata instead of relying on pbjson’s default event serialization behavior.
- Emit PostHog event/property keys in snake_case using `SerializeOptions::use_proto_field_name(true)`.
- Preserve falsy/default values (`false`, `0`, `""`) with `SerializeOptions::skip_default_fields(false)` so explicitly-set values are not dropped.
- Keep enum values in protobuf JSON string form (for readable PostHog querying), e.g. `"ACCOUNT_LINK_FLOW_DEVICE_CODE"`.
- Keep plugin/backend wire compatibility intact (pbjson remains the wire serializer), and update telemetry wasm fixtures to match the real oneof JSON shape used by the plugin.
- Add the `prost-reflect` dependency and keep descriptor generation in `build.rs` (including snake_case rename for the oneof enum serialize path).
