### PR TITLE
Track root redirect attribution in PostHog with privacy-safe anonymous IDs

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1062,6 +1062,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,6 +1390,7 @@ checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0"
 thiserror = "2.0.17"
 http = "1.4.0"
 once_cell = "1.21.4"
-uuid = { version = "1.23.0", features = ["js", "v4"] }
+uuid = { version = "1.23.0", features = ["js", "v4", "v5"] }
 nanoid = "0.4"
 url = "2"
 getrandom = { version = "0.2", features = ["js"] }

--- a/backend/src/posthog.rs
+++ b/backend/src/posthog.rs
@@ -25,6 +25,8 @@ use once_cell::sync::Lazy;
 use prost::Message;
 use prost_reflect::{DescriptorPool, DynamicMessage, SerializeOptions};
 use serde_json::{json, Value};
+use url::Url;
+use uuid::Uuid;
 use worker::wasm_bindgen::JsValue;
 use worker::{Fetch, Headers, Method, Request, RequestInit};
 
@@ -34,10 +36,19 @@ const POSTHOG_CAPTURE_PATH: &str = "/i/v0/e/";
 const LIB_NAME: &str = "studio-activity-backend";
 const LIB_VERSION: &str = env!("CARGO_PKG_VERSION");
 const TELEMETRY_REQUEST_DESCRIPTOR_NAME: &str = "api.v1.TelemetryRequest";
+const UTM_PARAM_KEYS: [&str; 5] = [
+    "utm_source",
+    "utm_medium",
+    "utm_campaign",
+    "utm_content",
+    "utm_term",
+];
 
 static DESCRIPTOR_POOL: Lazy<DescriptorPool> = Lazy::new(|| {
-    DescriptorPool::decode(include_bytes!(concat!(env!("OUT_DIR"), "/proto_descriptor.bin")).as_ref())
-        .expect("api.v1 descriptor pool")
+    DescriptorPool::decode(
+        include_bytes!(concat!(env!("OUT_DIR"), "/proto_descriptor.bin")).as_ref(),
+    )
+    .expect("api.v1 descriptor pool")
 });
 
 fn posthog_serialize_options() -> SerializeOptions {
@@ -90,10 +101,10 @@ pub fn decompose_event(event: &Event) -> (String, Value) {
     let Some(event_oneof) = descriptor.oneofs().find(|oneof| oneof.name() == "event") else {
         return (String::new(), json!({}));
     };
-    let Some((name, mut properties)) = event_oneof
-        .fields()
-        .find_map(|field| map.remove(field.name()).map(|value| (field.name().to_owned(), value)))
-    else {
+    let Some((name, mut properties)) = event_oneof.fields().find_map(|field| {
+        map.remove(field.name())
+            .map(|value| (field.name().to_owned(), value))
+    }) else {
         return (String::new(), json!({}));
     };
 
@@ -274,6 +285,133 @@ fn build_screen_payload(api_key: &str, req: &TelemetryRequest, client_ip: Option
         "distinct_id": req.distinct_id,
         "properties": properties,
     })
+}
+
+/// Extracts UTM parameters from a fully-qualified URL.
+fn extract_utm_from_url(current_url: &str) -> serde_json::Map<String, Value> {
+    let mut out = serde_json::Map::new();
+
+    let Ok(url) = Url::parse(current_url) else {
+        return out;
+    };
+
+    for (key, value) in url.query_pairs() {
+        let key = key.as_ref();
+        if !UTM_PARAM_KEYS.contains(&key) {
+            continue;
+        }
+
+        let value = value.trim();
+        if value.is_empty() {
+            continue;
+        }
+
+        out.insert(key.to_string(), json!(value));
+    }
+
+    out
+}
+
+/// Attempts to parse the host from a referrer URL.
+fn referring_domain(referrer: &str) -> Option<String> {
+    let parsed = Url::parse(referrer).ok()?;
+    parsed.host_str().map(ToOwned::to_owned)
+}
+
+/// Builds a deterministic, anonymous distinct id for server-side pageviews.
+///
+/// We hash a fingerprint of `client_ip + user_agent` using UUID v5 with a
+/// per-deployment salt, so IDs are stable for attribution but still anonymous.
+/// If both inputs are absent we fall back to a random UUID to avoid creating
+/// one shared "unknown" identity across many visitors.
+fn stable_pageview_distinct_id(
+    salt: &str,
+    client_ip: Option<&str>,
+    user_agent: Option<&str>,
+) -> String {
+    let ip = client_ip.map(str::trim).filter(|value| !value.is_empty());
+    let ua = user_agent.map(str::trim).filter(|value| !value.is_empty());
+
+    if ip.is_none() && ua.is_none() {
+        return Uuid::new_v4().to_string();
+    }
+
+    let fingerprint = format!(
+        "root_pageview_v1|{salt}|{}|{}",
+        ip.unwrap_or("unknown_ip"),
+        ua.unwrap_or("unknown_ua")
+    );
+    Uuid::new_v5(&Uuid::NAMESPACE_URL, fingerprint.as_bytes()).to_string()
+}
+
+/// Builds an anonymous `$pageview` payload for root-domain attribution.
+pub fn build_pageview_payload(
+    api_key: &str,
+    distinct_id_salt: Option<&str>,
+    current_url: &str,
+    referrer: Option<&str>,
+    user_agent: Option<&str>,
+    client_ip: Option<&str>,
+) -> Value {
+    let mut properties = serde_json::Map::new();
+    properties.insert("$current_url".into(), json!(current_url));
+    properties.insert("$lib".into(), json!(LIB_NAME));
+    properties.insert("$lib_version".into(), json!(LIB_VERSION));
+    properties.insert("$process_person_profile".into(), json!(false));
+
+    properties.extend(extract_utm_from_url(current_url));
+
+    if let Some(value) = referrer.map(str::trim).filter(|value| !value.is_empty()) {
+        properties.insert("$referrer".into(), json!(value));
+
+        if let Some(domain) = referring_domain(value) {
+            properties.insert("$referring_domain".into(), json!(domain));
+        }
+    }
+
+    if let Some(value) = user_agent.map(str::trim).filter(|value| !value.is_empty()) {
+        properties.insert("$useragent".into(), json!(value));
+    }
+
+    if let Some(value) = client_ip.map(str::trim).filter(|value| !value.is_empty()) {
+        properties.insert("$ip".into(), json!(value));
+    }
+
+    let distinct_id =
+        stable_pageview_distinct_id(distinct_id_salt.unwrap_or(api_key), client_ip, user_agent);
+
+    json!({
+        "api_key": api_key,
+        "event": "$pageview",
+        "distinct_id": distinct_id,
+        "properties": properties,
+    })
+}
+
+/// Forwards a prebuilt payload to PostHog capture.
+pub async fn forward_payload(host: &str, payload: &Value) {
+    send_to_posthog(host, payload).await;
+}
+
+/// Forwards an anonymous `$pageview` event for root-domain attribution.
+pub async fn forward_pageview(
+    host: &str,
+    api_key: &str,
+    distinct_id_salt: Option<&str>,
+    current_url: &str,
+    referrer: Option<&str>,
+    user_agent: Option<&str>,
+    client_ip: Option<&str>,
+) {
+    let payload = build_pageview_payload(
+        api_key,
+        distinct_id_salt,
+        current_url,
+        referrer,
+        user_agent,
+        client_ip,
+    );
+    forward_payload(host, &payload).await;
 }
 
 /// Sends a JSON payload to the PostHog capture API. Errors are logged,

--- a/backend/src/posthog.rs
+++ b/backend/src/posthog.rs
@@ -377,8 +377,13 @@ pub fn build_pageview_payload(
         properties.insert("$ip".into(), json!(value));
     }
 
-    let distinct_id =
-        stable_pageview_distinct_id(distinct_id_salt.unwrap_or(api_key), client_ip, user_agent);
+    let distinct_id = distinct_id_salt
+        .map(str::trim)
+        .filter(|salt| !salt.is_empty())
+        .map_or_else(
+            || Uuid::new_v4().to_string(),
+            |salt| stable_pageview_distinct_id(salt, client_ip, user_agent),
+        );
 
     json!({
         "api_key": api_key,

--- a/backend/src/routes/gh_redirect.rs
+++ b/backend/src/routes/gh_redirect.rs
@@ -1,6 +1,108 @@
-use axum::response::Redirect;
+use axum::extract::Request;
+use axum::http::{header, HeaderMap, HeaderValue};
+use axum::response::{IntoResponse, Redirect, Response};
+use worker::send::SendFuture;
 
-#[tracing::instrument]
-pub async fn gh_redirect() -> Redirect {
-    Redirect::permanent("https://github.com/grilme99/studio-activity")
+use crate::extractors::{Edge, WorkerContext};
+use crate::posthog;
+
+const DEFAULT_POSTHOG_HOST: &str = "https://us.i.posthog.com";
+const GITHUB_REPO_URL: &str = "https://github.com/grilme99/studio-activity";
+
+#[allow(clippy::must_use_candidate)]
+#[tracing::instrument(
+    skip(req),
+    fields(
+        utm_source = tracing::field::Empty,
+        referring_domain = tracing::field::Empty
+    )
+)]
+pub fn gh_redirect(
+    Edge(edge): Edge,
+    req: Request,
+) -> SendFuture<impl std::future::Future<Output = Response>> {
+    SendFuture::new(async move {
+        let mut redirect = Redirect::temporary(GITHUB_REPO_URL).into_response();
+        redirect
+            .headers_mut()
+            .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+
+        let headers: HeaderMap = req.headers().clone();
+        let env = req.extensions().get::<worker::Env>().cloned();
+        let ctx = req.extensions().get::<WorkerContext>().cloned();
+        let (Some(env), Some(WorkerContext(ctx_arc))) = (env, ctx) else {
+            return redirect;
+        };
+
+        let posthog_host = env
+            .var("POSTHOG_HOST")
+            .map_or_else(|_| DEFAULT_POSTHOG_HOST.to_string(), |v| v.to_string());
+
+        let api_key = match env.secret("POSTHOG_API_KEY") {
+            Ok(key) => key.to_string(),
+            Err(e) => {
+                tracing::error!(error = %e, "POSTHOG_API_KEY secret not configured");
+                return redirect;
+            }
+        };
+
+        let public_url = match env.var("BACKEND_PUBLIC_URL") {
+            Ok(url) => url.to_string(),
+            Err(e) => {
+                tracing::warn!(error = %e, "BACKEND_PUBLIC_URL var not configured");
+                return redirect;
+            }
+        };
+
+        let path_and_query = req.uri().path_and_query().map_or("/", |pq| pq.as_str());
+        let current_url = format!("{}{}", public_url.trim_end_matches('/'), path_and_query);
+
+        let referrer = headers
+            .get(header::REFERER)
+            .and_then(|value| value.to_str().ok())
+            .map(ToOwned::to_owned);
+
+        let user_agent = headers
+            .get(header::USER_AGENT)
+            .and_then(|value| value.to_str().ok())
+            .map(ToOwned::to_owned);
+
+        // Optional secret salt for deterministic anonymous distinct ids.
+        // Falls back to API key when unset so no new config is required.
+        let distinct_id_salt = env
+            .secret("POSTHOG_DISTINCT_ID_SALT")
+            .map_or_else(|_| api_key.clone(), |value| value.to_string());
+
+        let client_ip = edge.client_ip;
+        let payload = posthog::build_pageview_payload(
+            &api_key,
+            Some(&distinct_id_salt),
+            &current_url,
+            referrer.as_deref(),
+            user_agent.as_deref(),
+            client_ip.as_deref(),
+        );
+
+        let props = payload
+            .get("properties")
+            .and_then(|value| value.as_object());
+        if let Some(utm_source) = props
+            .and_then(|properties| properties.get("utm_source"))
+            .and_then(|value| value.as_str())
+        {
+            tracing::Span::current().record("utm_source", utm_source);
+        }
+        if let Some(domain) = props
+            .and_then(|properties| properties.get("$referring_domain"))
+            .and_then(|value| value.as_str())
+        {
+            tracing::Span::current().record("referring_domain", domain);
+        }
+
+        ctx_arc.wait_until(async move {
+            posthog::forward_payload(&posthog_host, &payload).await;
+        });
+
+        redirect
+    })
 }

--- a/backend/src/routes/gh_redirect.rs
+++ b/backend/src/routes/gh_redirect.rs
@@ -68,15 +68,22 @@ pub fn gh_redirect(
             .map(ToOwned::to_owned);
 
         // Optional secret salt for deterministic anonymous distinct ids.
-        // Falls back to API key when unset so no new config is required.
-        let distinct_id_salt = env
-            .secret("POSTHOG_DISTINCT_ID_SALT")
-            .map_or_else(|_| api_key.clone(), |value| value.to_string());
+        // If unset, we intentionally use per-request random IDs.
+        let distinct_id_salt = match env.secret("POSTHOG_DISTINCT_ID_SALT") {
+            Ok(value) => Some(value.to_string()),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "POSTHOG_DISTINCT_ID_SALT not configured; using per-request random anonymous distinct_id"
+                );
+                None
+            }
+        };
 
         let client_ip = edge.client_ip;
         let payload = posthog::build_pageview_payload(
             &api_key,
-            Some(&distinct_id_salt),
+            distinct_id_salt.as_deref(),
             &current_url,
             referrer.as_deref(),
             user_agent.as_deref(),

--- a/backend/tests/wasm.rs
+++ b/backend/tests/wasm.rs
@@ -23,3 +23,6 @@ pub mod routing;
 
 #[path = "wasm/telemetry.rs"]
 pub mod telemetry;
+
+#[path = "wasm/posthog_pageview.rs"]
+pub mod posthog_pageview;

--- a/backend/tests/wasm/extractors.rs
+++ b/backend/tests/wasm/extractors.rs
@@ -15,5 +15,8 @@ async fn missing_edge_context_returns_500() {
 
     let json = body_json(resp).await;
     assert_eq!(json["type"], "/errors/internal");
-    assert!(json.get("detail").is_none(), "internal context must not leak");
+    assert!(
+        json.get("detail").is_none(),
+        "internal context must not leak"
+    );
 }

--- a/backend/tests/wasm/middleware.rs
+++ b/backend/tests/wasm/middleware.rs
@@ -42,6 +42,12 @@ async fn missing_cf_ray_generates_fallback_request_id() {
         .expect("x-request-id header should be set")
         .to_str()
         .unwrap();
-    assert!(!request_id.is_empty(), "fallback request id should not be empty");
-    assert_ne!(request_id, "unknown", "should generate a UUID, not 'unknown'");
+    assert!(
+        !request_id.is_empty(),
+        "fallback request id should not be empty"
+    );
+    assert_ne!(
+        request_id, "unknown",
+        "should generate a UUID, not 'unknown'"
+    );
 }

--- a/backend/tests/wasm/posthog_pageview.rs
+++ b/backend/tests/wasm/posthog_pageview.rs
@@ -1,0 +1,134 @@
+use backend::posthog::build_pageview_payload;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+async fn pageview_payload_includes_all_utm_parameters() {
+    let current_url = "https://activity.brooke.sh/?utm_source=twitter&utm_medium=social&utm_campaign=launch&utm_content=hero&utm_term=plugin";
+    let payload = build_pageview_payload(
+        "test-key",
+        None,
+        current_url,
+        Some("https://t.co/example"),
+        Some("Mozilla/5.0"),
+        Some("192.0.2.1"),
+    );
+
+    let props = payload["properties"].as_object().unwrap();
+    assert_eq!(payload["event"], "$pageview");
+    assert_eq!(props["$current_url"], current_url);
+    assert_eq!(props["utm_source"], "twitter");
+    assert_eq!(props["utm_medium"], "social");
+    assert_eq!(props["utm_campaign"], "launch");
+    assert_eq!(props["utm_content"], "hero");
+    assert_eq!(props["utm_term"], "plugin");
+}
+
+#[wasm_bindgen_test]
+async fn pageview_payload_omits_utm_keys_when_absent() {
+    let payload = build_pageview_payload(
+        "test-key",
+        None,
+        "https://activity.brooke.sh/",
+        Some("https://example.com/landing"),
+        None,
+        None,
+    );
+
+    let props = payload["properties"].as_object().unwrap();
+    for key in [
+        "utm_source",
+        "utm_medium",
+        "utm_campaign",
+        "utm_content",
+        "utm_term",
+    ] {
+        assert!(!props.contains_key(key));
+    }
+}
+
+#[wasm_bindgen_test]
+async fn pageview_payload_sets_referrer_and_domain() {
+    let payload = build_pageview_payload(
+        "test-key",
+        None,
+        "https://activity.brooke.sh/?utm_source=discord",
+        Some("https://twitter.com/someone/status/123"),
+        Some("Mozilla/5.0"),
+        Some("198.51.100.2"),
+    );
+
+    let props = payload["properties"].as_object().unwrap();
+    assert_eq!(props["$referrer"], "https://twitter.com/someone/status/123");
+    assert_eq!(props["$referring_domain"], "twitter.com");
+    assert_eq!(props["$process_person_profile"], false);
+    assert_eq!(props["$useragent"], "Mozilla/5.0");
+    assert_eq!(props["$ip"], "198.51.100.2");
+    assert!(payload["distinct_id"]
+        .as_str()
+        .is_some_and(|distinct_id| !distinct_id.is_empty()));
+}
+
+#[wasm_bindgen_test]
+async fn pageview_payload_omits_referrer_fields_when_missing() {
+    let payload = build_pageview_payload(
+        "test-key",
+        None,
+        "https://activity.brooke.sh/?utm_source=discord",
+        None,
+        None,
+        None,
+    );
+
+    let props = payload["properties"].as_object().unwrap();
+    assert!(!props.contains_key("$referrer"));
+    assert!(!props.contains_key("$referring_domain"));
+    assert_eq!(props["$process_person_profile"], false);
+    assert_eq!(
+        props["$current_url"],
+        "https://activity.brooke.sh/?utm_source=discord"
+    );
+}
+
+#[wasm_bindgen_test]
+async fn pageview_payload_distinct_id_is_stable_for_same_visitor_fingerprint() {
+    let payload_a = build_pageview_payload(
+        "test-key",
+        Some("pepper"),
+        "https://activity.brooke.sh/?utm_source=discord",
+        None,
+        Some("Mozilla/5.0"),
+        Some("203.0.113.7"),
+    );
+    let payload_b = build_pageview_payload(
+        "test-key",
+        Some("pepper"),
+        "https://activity.brooke.sh/?utm_source=discord",
+        None,
+        Some("Mozilla/5.0"),
+        Some("203.0.113.7"),
+    );
+
+    assert_eq!(payload_a["distinct_id"], payload_b["distinct_id"]);
+}
+
+#[wasm_bindgen_test]
+async fn pageview_payload_distinct_id_changes_when_fingerprint_changes() {
+    let payload_a = build_pageview_payload(
+        "test-key",
+        Some("pepper"),
+        "https://activity.brooke.sh/?utm_source=discord",
+        None,
+        Some("Mozilla/5.0"),
+        Some("203.0.113.7"),
+    );
+    let payload_b = build_pageview_payload(
+        "test-key",
+        Some("pepper"),
+        "https://activity.brooke.sh/?utm_source=discord",
+        None,
+        Some("Mozilla/5.0"),
+        Some("203.0.113.8"),
+    );
+
+    assert_ne!(payload_a["distinct_id"], payload_b["distinct_id"]);
+}

--- a/backend/tests/wasm/redirect.rs
+++ b/backend/tests/wasm/redirect.rs
@@ -6,7 +6,7 @@ use wasm_bindgen_test::*;
 use crate::helpers::{inject_edge, mock_edge_context, test_router};
 
 #[wasm_bindgen_test]
-async fn root_returns_permanent_redirect() {
+async fn root_returns_temporary_redirect() {
     let app = test_router();
     let req = inject_edge(
         Request::get("/").body(Body::empty()).unwrap(),
@@ -14,7 +14,14 @@ async fn root_returns_permanent_redirect() {
     );
 
     let resp = app.oneshot(req).await.unwrap();
-    assert_eq!(resp.status(), StatusCode::PERMANENT_REDIRECT);
+    assert_eq!(resp.status(), StatusCode::TEMPORARY_REDIRECT);
+    let cache_control = resp
+        .headers()
+        .get("cache-control")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert_eq!(cache_control, "no-store");
 }
 
 #[wasm_bindgen_test]

--- a/backend/tests/wasm/telemetry.rs
+++ b/backend/tests/wasm/telemetry.rs
@@ -303,9 +303,7 @@ async fn telemetry_missing_content_type_returns_error() {
     let app = test_router();
     let req = inject_edge(
         Request::post("/v1/telemetry")
-            .body(Body::from(
-                r#"{"distinctId":"u","pluginLoaded":{}}"#,
-            ))
+            .body(Body::from(r#"{"distinctId":"u","pluginLoaded":{}}"#))
             .unwrap(),
         mock_edge_context(),
     );


### PR DESCRIPTION
## Summary

This PR adds source attribution for `activity.brooke.sh` root traffic and hardens anonymous identity handling.
- Captures a server-side PostHog `$pageview` for `GET /` with:
  - `$current_url`
  - `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`
  - `$referrer`, `$referring_domain`
  - `$ip`, `$useragent`
  - `$process_person_profile = false`
- Changes root redirect behavior from permanent to temporary and non-cacheable:
  - `307 Temporary Redirect`
  - `Cache-Control: no-store`

## Why

- Enable UTM/referrer discovery insights in PostHog.
- Ensure attribution is recorded on repeated visits (avoid browser caching of permanent redirect).
- Keep attribution privacy-aware without coupling ID derivation to ingestion credentials.
